### PR TITLE
Adds build tag nokafka to remove kafka libraries

### DIFF
--- a/logging/config.go
+++ b/logging/config.go
@@ -1,16 +1,17 @@
-package main
+package logging
 
 import (
 	"bytes"
-	"github.com/labstack/echo"
-	"github.com/labstack/gommon/color"
-	"github.com/valyala/fasttemplate"
 	"io"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/labstack/echo"
+	"github.com/labstack/gommon/color"
+	"github.com/valyala/fasttemplate"
 )
 
 type (

--- a/logging/handler.go
+++ b/logging/handler.go
@@ -1,0 +1,65 @@
+// +build !nokafka
+
+package logging
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/connectome-neuprint/neuPrintHTTP/config"
+	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+)
+
+type kafkaLog struct {
+	Producer *kafka.Producer
+	Topic    string
+}
+
+func (k *kafkaLog) Write(p []byte) (int, error) {
+	kafkaMsg := &kafka.Message{
+
+		TopicPartition: kafka.TopicPartition{Topic: &k.Topic, Partition: kafka.PartitionAny},
+
+		Value: p,
+
+		Timestamp: time.Now(),
+	}
+
+	if err := k.Producer.Produce(kafkaMsg, nil); err != nil {
+		return 0, err
+	}
+
+	return len(p), nil
+
+}
+
+// GetLogger gets a logging handler
+func GetLogger(port int, options config.Config) (io.Writer, error) {
+
+	logFile := os.Stdout
+	var err error
+
+	if options.LoggerFile != "" {
+		if logFile, err = os.OpenFile(options.LoggerFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err != nil {
+			fmt.Println(err)
+			return nil, err
+		}
+		defer logFile.Close()
+	}
+	logWriter := io.Writer(logFile)
+
+	// use kafka for logging if available
+	if len(options.KafkaServers) > 0 {
+		serverstr := strings.Join(options.KafkaServers, ",")
+		kp, _ := kafka.NewProducer(&kafka.ConfigMap{"bootstrap.servers": serverstr})
+
+		portstr := strconv.Itoa(port)
+		logWriter = &kafkaLog{kp, "neuprint_" + options.Hostname + "_" + portstr}
+	}
+
+	return logWriter, nil
+}

--- a/logging/handler.nokafka.go
+++ b/logging/handler.nokafka.go
@@ -1,0 +1,28 @@
+// +build nokafka
+
+package logging
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/connectome-neuprint/neuPrintHTTP/config"
+)
+
+// GetLogger gets a logging handler
+func GetLogger(port int, options config.Config) (io.Writer, error) {
+
+	logFile := os.Stdout
+	var err error
+
+	if options.LoggerFile != "" {
+		if logFile, err = os.OpenFile(options.LoggerFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err != nil {
+			fmt.Println(err)
+			return nil, err
+		}
+		defer logFile.Close()
+	}
+	logWriter := io.Writer(logFile)
+	return logWriter, nil
+}


### PR DESCRIPTION
The kafka library is an external dependency that isn't always needed.
This new build flag allows us to disable kafka and remove it from the
final binary.