### PR TITLE
modify all hardwired Cypher to return strings

### DIFF
--- a/api/cached/cached.go
+++ b/api/cached/cached.go
@@ -181,7 +181,7 @@ func (ca cypherAPI) getROIConnectivity_int(dataset string) (interface{}, error) 
 	cypher := `
 		MATCH (neuron :Neuron)
 		RETURN
-			neuron.bodyId AS bodyid,
+			toString(neuron.bodyId) AS bodyid,
 			neuron.roiInfo AS roiInfo
 	`
 	res, err := ca.Store.GetMain(dataset).CypherRequest(cypher, true)
@@ -577,7 +577,7 @@ func (ca cypherAPI) getDailyType_int(dataset string) ([]byte, error) {
 	}
 
 	// fetch connection info (for sunburst plot)
-	connection_info := "MATCH (n :Neuron {bodyId: {bodyid}})-[x :ConnectsTo]->(m) RETURN m.bodyId, m.type, x.weight, x.roiInfo, m.status, 'downstream' as direction UNION MATCH (n :Neuron {bodyId: {bodyid}})<-[x :ConnectsTo]-(m) RETURN m.bodyId, m.type, x.weight, x.roiInfo, m.status, 'upstream' as direction"
+	connection_info := "MATCH (n :Neuron {bodyId: {bodyid}})-[x :ConnectsTo]->(m) RETURN toString(m.bodyId) as bodyId, m.type, x.weight, x.roiInfo, m.status, 'downstream' as direction UNION MATCH (n :Neuron {bodyId: {bodyid}})<-[x :ConnectsTo]-(m) RETURN toString(m.bodyId) as bodyId, m.type, x.weight, x.roiInfo, m.status, 'upstream' as direction"
 	connection_info = strings.Replace(connection_info, "{bodyid}", strconv.FormatInt(bodyid, 10), -1)
 
 	conninfo_res, err := requester.CypherRequest(connection_info, true)
@@ -656,7 +656,7 @@ func (ca cypherAPI) getDailyType_int(dataset string) ([]byte, error) {
 	info["numtype"] = numtype
 	info["numpre"] = numpre
 	info["numpost"] = numpost
-	info["bodyid"] = bodyid
+	info["bodyid"] = strconv.FormatInt(bodyid, 10)
 	output["info"] = info
 	output["skeleton"] = skeleton
 

--- a/api/npexplorer/cypher.go
+++ b/api/npexplorer/cypher.go
@@ -11,23 +11,23 @@ const (
 
 	NeuronMetaValsQuery = "MATCH (n :Neuron) RETURN DISTINCT n.{metakey} AS val"
 
-	ROIQuery = "MATCH (neuron :Neuron) RETURN neuron.bodyId AS bodyid, neuron.roiInfo AS roiInfo"
+	ROIQuery = "MATCH (neuron :Neuron) RETURN toString(neuron.bodyId) AS bodyid, neuron.roiInfo AS roiInfo"
 
-	AutapsesQuery = "MATCH (n:Neuron)-[x:ConnectsTo]->(n) RETURN n.bodyId AS id, x.weight AS weight, n.instance AS name, n.type AS type ORDER BY x.weight DESC"
+	AutapsesQuery = "MATCH (n:Neuron)-[x:ConnectsTo]->(n) RETURN toString(n.bodyId) AS id, x.weight AS weight, n.instance AS name, n.type AS type ORDER BY x.weight DESC"
 
 	CompletenessQuery = "MATCH (n:{NeuronSegment}) {has_conditions} {pre_cond} {post_cond} {status_conds} WITH apoc.convert.fromJsonMap(n.roiInfo) AS roiInfo WITH roiInfo AS roiInfo, keys(roiInfo) AS roiList UNWIND roiList AS roiName WITH roiName AS roiName, sum(roiInfo[roiName].pre) AS pre, sum(roiInfo[roiName].post) AS post MATCH (meta:Meta) WITH apoc.convert.fromJsonMap(meta.roiInfo) AS globInfo, roiName AS roiName, pre AS pre, post AS post RETURN roiName AS unlabelres, pre AS roipre, post AS roipost, globInfo[roiName].pre AS totalpre, globInfo[roiName].post AS totalpost ORDER BY roiName"
 
-	DistributionQuery = "MATCH (n:Segment {`{ROI}`: true}) {preorpost_filter} WITH n.bodyId as bodyId, apoc.convert.fromJsonMap(n.roiInfo)[\"{ROI}\"].{preorpost} AS {preorpost}size WHERE {preorpost}size > 0 WITH collect({id: bodyId, {preorpost}: {preorpost}size}) as bodyinfoarr, sum({preorpost}size) AS tot UNWIND bodyinfoarr AS bodyinfo RETURN bodyinfo.id AS id, bodyinfo.{preorpost} AS size, tot AS total ORDER BY bodyinfo.{preorpost} DESC"
+	DistributionQuery = "MATCH (n:Segment {`{ROI}`: true}) {preorpost_filter} WITH toString(n.bodyId) as bodyId, apoc.convert.fromJsonMap(n.roiInfo)[\"{ROI}\"].{preorpost} AS {preorpost}size WHERE {preorpost}size > 0 WITH collect({id: bodyId, {preorpost}: {preorpost}size}) as bodyinfoarr, sum({preorpost}size) AS tot UNWIND bodyinfoarr AS bodyinfo RETURN bodyinfo.id AS id, bodyinfo.{preorpost} AS size, tot AS total ORDER BY bodyinfo.{preorpost} DESC"
 
-	IntersectingROIQuery = "MATCH (neuron :Neuron) WHERE {neuronid} RETURN neuron.bodyId AS bodyid, neuron.instance AS bodyname, neuron.type AS bodytype, neuron.roiInfo AS roiInfo ORDER BY neuron.bodyId"
+	IntersectingROIQuery = "MATCH (neuron :Neuron) WHERE {neuronid} RETURN toString(neuron.bodyId) AS bodyid, neuron.instance AS bodyname, neuron.type AS bodytype, neuron.roiInfo AS roiInfo ORDER BY neuron.bodyId"
 
-  SimpleConnectionsQuery = " MATCH (m:Meta) WITH m.superLevelRois AS rois MATCH (m:Neuron){connection}(n:Segment) WHERE {neuronid} RETURN m.instance AS Neuron1, m.type AS Neuron1Type, n.instance AS Neuron2, n.type AS Neuron2Type, n.bodyId AS Neuron2Id, e.weight AS Weight, m.bodyId AS Neuron1Id, n.status AS Neuron2Status, n.roiInfo AS Neuron2RoiInfo, n.size AS Neuron2Size, n.pre AS Neuron2Pre, n.post AS Neuron2Post, rois, e.weightHP AS WeightHP ORDER BY m.type, m.bodyId, e.weight DESC"
+	SimpleConnectionsQuery = " MATCH (m:Meta) WITH m.superLevelRois AS rois MATCH (m:Neuron){connection}(n:Segment) WHERE {neuronid} RETURN m.instance AS Neuron1, m.type AS Neuron1Type, n.instance AS Neuron2, n.type AS Neuron2Type, toString(n.bodyId) AS Neuron2Id, e.weight AS Weight, toString(m.bodyId) AS Neuron1Id, n.status AS Neuron2Status, n.roiInfo AS Neuron2RoiInfo, n.size AS Neuron2Size, n.pre AS Neuron2Pre, n.post AS Neuron2Post, rois, e.weightHP AS WeightHP ORDER BY m.type, m.bodyId, e.weight DESC"
 
-	RankedTableQuery = "MATCH (m:Neuron)-[e:ConnectsTo]-(n) WHERE {neuronid} RETURN m.instance AS Neuron1, m.type AS Neuron1Type, n.instance AS Neuron2, n.type AS Neuron2Type, e.weight AS Weight, n.bodyId AS Body2, id(m) AS m_id, id(n) AS n_id, id(startNode(e)) AS pre_id, m.bodyId AS Body1, e.weightHP AS WeightHP ORDER BY m.bodyId, e.weight DESC"
+	RankedTableQuery = "MATCH (m:Neuron)-[e:ConnectsTo]-(n) WHERE {neuronid} RETURN m.instance AS Neuron1, m.type AS Neuron1Type, n.instance AS Neuron2, n.type AS Neuron2Type, e.weight AS Weight, toString(n.bodyId) AS Body2, id(m) AS m_id, id(n) AS n_id, id(startNode(e)) AS pre_id, toString(m.bodyId) AS Body1, e.weightHP AS WeightHP ORDER BY m.bodyId, e.weight DESC"
 
-	FindNeuronsQuery = " MATCH (m:Meta) WITH m.superLevelRois AS rois MATCH (neuron :{NeuronSegment}) {has_conditions} {neuronid} {pre_cond} {post_cond} {status_conds} {roi_list} RETURN neuron.bodyId AS bodyid, neuron.instance AS bodyname, neuron.type AS bodytype, neuron.status AS neuronStatus, neuron.roiInfo AS roiInfo, neuron.size AS size, neuron.pre AS npre, neuron.post AS npost, rois, neuron.notes as notes ORDER BY neuron.bodyId"
+	FindNeuronsQuery = " MATCH (m:Meta) WITH m.superLevelRois AS rois MATCH (neuron :{NeuronSegment}) {has_conditions} {neuronid} {pre_cond} {post_cond} {status_conds} {roi_list} RETURN toString(neuron.bodyId) AS bodyid, neuron.instance AS bodyname, neuron.type AS bodytype, neuron.status AS neuronStatus, neuron.roiInfo AS roiInfo, neuron.size AS size, neuron.pre AS npre, neuron.post AS npost, rois, neuron.notes as notes ORDER BY neuron.bodyId"
 
-	CommonConnectivityQuery = "WITH [{neuron_list}] AS queriedNeurons MATCH (k:{NeuronSegment}){connection}(c) WHERE (k.{idortype} IN queriedNeurons {pre_cond} {post_cond} {status_conds}) WITH k, c, r, toString(k.{idortype})+\"_weight\" AS dynamicWeight RETURN collect(apoc.map.fromValues([\"{inputoroutput}\", c.bodyId, \"name\", c.instance, \"type\", c.type, dynamicWeight, r.weight])) AS map"
+	CommonConnectivityQuery = "WITH [{neuron_list}] AS queriedNeurons MATCH (k:{NeuronSegment}){connection}(c) WHERE (k.{idortype} IN queriedNeurons {pre_cond} {post_cond} {status_conds}) WITH k, c, r, toString(k.{idortype})+\"_weight\" AS dynamicWeight RETURN collect(apoc.map.fromValues([\"{inputoroutput}\", toString(c.bodyId), \"name\", c.instance, \"type\", c.type, dynamicWeight, r.weight])) AS map"
 )
 
 // ExplorerFindNeurons implements API to find neurons in a certain ROI

--- a/api/roimeshes/roimeshes.go
+++ b/api/roimeshes/roimeshes.go
@@ -1,7 +1,7 @@
 package roimeshes
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/connectome-neuprint/neuPrintHTTP/api"
@@ -140,7 +140,7 @@ func (ma masterAPI) setMesh(c echo.Context) error {
 	}
 
 	// post the value
-	body, err := ioutil.ReadAll(c.Request().Body)
+	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		errJSON := api.ErrorInfo{Error: "error reading binary data"}
 		return c.JSON(http.StatusBadRequest, errJSON)

--- a/api/skeletons/skeletons.go
+++ b/api/skeletons/skeletons.go
@@ -2,7 +2,7 @@ package skeletons
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -60,7 +60,7 @@ func (ma masterAPI) getSkeleton(c echo.Context) error {
 	// - in: "path"
 	//   name: "id"
 	//   schema:
-	//     type: "integer"
+	//     type: "string"
 	//   required: true
 	//   description: "body id"
 	// - in: "query"
@@ -97,7 +97,7 @@ func (ma masterAPI) getSkeleton(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errJSON)
 	}
 
-	if _, err := strconv.Atoi(bodyid); err != nil {
+	if _, err := strconv.ParseInt(bodyid, 10, 64); err != nil {
 		errJSON := api.ErrorInfo{Error: "body id should be an integer"}
 		return c.JSON(http.StatusBadRequest, errJSON)
 	}
@@ -185,7 +185,7 @@ func (ma masterAPI) setSkeleton(c echo.Context) error {
 	// - in: "path"
 	//   name: "id"
 	//   schema:
-	//     type: "integer"
+	//     type: "string"
 	//   required: true
 	//   description: "body id"
 	// - in: "body"
@@ -205,7 +205,7 @@ func (ma masterAPI) setSkeleton(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errJSON)
 	}
 
-	if _, err := strconv.Atoi(bodyid); err != nil {
+	if _, err := strconv.ParseInt(bodyid, 10, 64); err != nil {
 		errJSON := api.ErrorInfo{Error: "body id should be an integer"}
 		return c.JSON(http.StatusBadRequest, errJSON)
 	}
@@ -223,7 +223,7 @@ func (ma masterAPI) setSkeleton(c echo.Context) error {
 	}
 	// post the value
 	keystr := bodyid + "_swc"
-	body, err := ioutil.ReadAll(c.Request().Body)
+	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		errJSON := api.ErrorInfo{Error: "error reading binary data"}
 		return c.JSON(http.StatusBadRequest, errJSON)


### PR DESCRIPTION
This should force `bodyId` to be returned as strings instead of int64 for all endpoints using hardwired Cypher. @neomorphic @stuarteberg 