### PR TITLE
Allow running full service with auth disabled.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# only commit the sample config
-*.config.json
-config.json
-
 # no certificates
 *.pem
 

--- a/config-examples/config.json
+++ b/config-examples/config.json
@@ -1,0 +1,35 @@
+{
+    "engine": "neuPrint-neo4j",
+    "engine-config": {
+	    "server": "<NEO4-SERVER>:7474",
+	    "user": "neo4j",
+	    "password": "<PASSWORD>"
+    },
+    "datatypes": { 
+	"skeletons" : [
+		{
+		"instance": "<UNIQUE NAME>",
+		"engine": "dvidkv",
+		"engine-config": {
+			"dataset": "hemibrain",
+			"server": "http://<DVIDADDR>",
+			"branch": "<UUID>",
+			"instance": "segmentation_skeletons"
+		}
+		},
+		{
+		"instance": "<UNIQUE NAME>",
+		"engine": "badger",
+		"engine-config": {
+			"dataset": "hemibrain",
+			"location": "<DIRECTORY LOCATION>"
+		}
+		}
+	]
+    },
+    "disable-auth": true,
+    "swagger-docs": "<NEUPRINT_HTTP_LOCATION>/swaggerdocs",
+    "log-file": "log.json",
+    "enable-arrow": true,
+    "arrow-flight-port": 11001
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "1.7.3"
+var Version = "1.7.4"

--- a/secure/secure.go
+++ b/secure/secure.go
@@ -18,6 +18,12 @@ import (
 // Horrible Hack
 var ProxyPort = 0
 
+// AccessLevel is an alias for AuthorizationLevel for backward compatibility
+type AccessLevel = AuthorizationLevel
+
+// SecureAPI is an alias for EchoSecure for backward compatibility
+type SecureAPI = EchoSecure
+
 // SecureConfig provides configuration options when initializing echo
 type SecureConfig struct {
 	SSLCert          string     // filename for SSL certificate (should be .PEM file) (default auto TLS)
@@ -146,7 +152,7 @@ func (s EchoSecure) AuthMiddleware(authLevel AuthorizationLevel) echo.Middleware
 // API is created.  Authentication routes are addded in the default
 // echo context group.  Note: do not add auth middleware to the default context
 // since it will disable login.
-func InitializeEchoSecure(e *echo.Echo, config SecureConfig, secret []byte, sessionID string) (EchoSecure, error) {
+func InitializeEchoSecure(e *echo.Echo, config SecureConfig, secret []byte, sessionID string) (*EchoSecure, error) {
 	// setup logging and panic recover
 	manCert := false
 	if config.SSLCert != "" && config.SSLKey != "" {
@@ -180,7 +186,7 @@ func InitializeEchoSecure(e *echo.Echo, config SecureConfig, secret []byte, sess
 		enableAuthorize = false
 	}
 
-	s := EchoSecure{e, secret, enableAuthenticate, enableAuthorize, manCert, config}
+	s := &EchoSecure{e, secret, enableAuthenticate, enableAuthorize, manCert, config}
 	ProxyAuth = config.ProxyAuth
 
 	if enableAuthenticate {


### PR DESCRIPTION
Before, running with auth disabled (using `disable-auth` property set to `true` in config.json) would only provide API docs. This PR allows the service to provide all the normal endpoints with auth disabled. @stuarteberg @neomorphic 